### PR TITLE
remove unnecessary error message

### DIFF
--- a/frontend/src/views/NewSecretView.vue
+++ b/frontend/src/views/NewSecretView.vue
@@ -191,6 +191,7 @@ export default {
                     response.data.secret_id,
                 ].join("/");
                 this.encryptSuccess = true;
+                this.encryptFailure = false;
             } catch (err) {
                 if (err.response.status == 400) {
                     this.encryptFailure = true;


### PR DESCRIPTION
if we try with a short passphrase then with a longer passphrase and we store it successfully, remove previous failure message